### PR TITLE
Add GenerateTargetFrameworkAttribute to Shared Projects

### DIFF
--- a/src/content/MSTest-Appium-CSharp/UITests.Shared/UITests.Shared.csproj
+++ b/src/content/MSTest-Appium-CSharp/UITests.Shared/UITests.Shared.csproj
@@ -5,6 +5,7 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <GenerateMSBuildEditorConfigFile>False</GenerateMSBuildEditorConfigFile>
+    <GenerateTargetFrameworkAttribute>False</GenerateTargetFrameworkAttribute>
     <RootNamespace>UITests</RootNamespace>
   </PropertyGroup>
 

--- a/src/content/NUnit-Appium-CSharp/UITests.Shared/UITests.Shared.csproj
+++ b/src/content/NUnit-Appium-CSharp/UITests.Shared/UITests.Shared.csproj
@@ -5,6 +5,7 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <GenerateMSBuildEditorConfigFile>False</GenerateMSBuildEditorConfigFile>
+    <GenerateTargetFrameworkAttribute>False</GenerateTargetFrameworkAttribute>
     <RootNamespace>UITests</RootNamespace>
   </PropertyGroup>
 

--- a/src/content/xUnit-Appium-CSharp/UITests.Shared/UITests.Shared.csproj
+++ b/src/content/xUnit-Appium-CSharp/UITests.Shared/UITests.Shared.csproj
@@ -5,6 +5,7 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <GenerateMSBuildEditorConfigFile>False</GenerateMSBuildEditorConfigFile>
+    <GenerateTargetFrameworkAttribute>False</GenerateTargetFrameworkAttribute>
     <RootNamespace>UITests</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
Adds the `GenerateTargetFrameworkAttribute` to the Shared projects to prevent build errors. This should be OK since the Shared project in itself should not create any type of assembly anyway.

Fixes #9