### PR TITLE
Fix MSTest init & cleanup

### DIFF
--- a/src/content/MSTest-Appium-CSharp/UITests.Android/AppiumSetup.cs
+++ b/src/content/MSTest-Appium-CSharp/UITests.Android/AppiumSetup.cs
@@ -14,7 +14,7 @@ public class AppiumSetup
 	public static AppiumDriver App => driver ?? throw new NullReferenceException("AppiumDriver is null");
 
 	[AssemblyInitialize]
-	public void RunBeforeAnyTests()
+	public static void RunBeforeAnyTests(TestContext context)
 	{
 #if (includeAppiumServerStartup)
 		// If you started an Appium server manually, make sure to comment out the next line
@@ -60,7 +60,7 @@ public class AppiumSetup
 	}
 
 	[AssemblyCleanup]
-	public void RunAfterAnyTests()
+	public static void RunAfterAnyTests()
 	{
 		driver?.Quit();
 #if (includeAppiumServerStartup)

--- a/src/content/MSTest-Appium-CSharp/UITests.Windows/AppiumSetup.cs
+++ b/src/content/MSTest-Appium-CSharp/UITests.Windows/AppiumSetup.cs
@@ -13,7 +13,7 @@ public class AppiumSetup
 	public static AppiumDriver App => driver ?? throw new NullReferenceException("AppiumDriver is null");
 
 	[AssemblyInitialize]
-	public void RunBeforeAnyTests()
+	public static void RunBeforeAnyTests(TestContext context)
 	{
 #if (includeAppiumServerStartup)
 		// If you started an Appium server manually, make sure to comment out the next line
@@ -37,7 +37,7 @@ public class AppiumSetup
 	}
 
 	[AssemblyCleanup]
-	public void RunAfterAnyTests()
+	public static void RunAfterAnyTests()
 	{
 		driver?.Quit();
 #if (includeAppiumServerStartup)

--- a/src/content/MSTest-Appium-CSharp/UITests.iOS/AppiumSetup.cs
+++ b/src/content/MSTest-Appium-CSharp/UITests.iOS/AppiumSetup.cs
@@ -13,7 +13,7 @@ public class AppiumSetup
 	public static AppiumDriver App => driver ?? throw new NullReferenceException("AppiumDriver is null");
 
 	[AssemblyInitialize]
-	public void RunBeforeAnyTests()
+	public static void RunBeforeAnyTests(TestContext context)
 	{
 #if (includeAppiumServerStartup)
 		// If you started an Appium server manually, make sure to comment out the next line
@@ -41,7 +41,7 @@ public class AppiumSetup
 	}
 
 	[AssemblyCleanup]
-	public void RunAfterAnyTests()
+	public static void RunAfterAnyTests()
 	{
 		driver?.Quit();
 #if (includeAppiumServerStartup)

--- a/src/content/MSTest-Appium-CSharp/UITests.macOS/AppiumSetup.cs
+++ b/src/content/MSTest-Appium-CSharp/UITests.macOS/AppiumSetup.cs
@@ -14,7 +14,7 @@ public class AppiumSetup
 	public static AppiumDriver App => driver ?? throw new NullReferenceException("AppiumDriver is null");
 
 	[AssemblyInitialize]
-	public void RunBeforeAnyTests()
+	public static void RunBeforeAnyTests(TestContext context)
 	{
 #if (includeAppiumServerStartup)
 		// If you started an Appium server manually, make sure to comment out the next line
@@ -41,7 +41,7 @@ public class AppiumSetup
 	}
 
 	[AssemblyCleanup]
-	public void RunAfterAnyTests()
+	public static void RunAfterAnyTests()
 	{
 		driver?.Quit();
 #if (includeAppiumServerStartup)


### PR DESCRIPTION
The MSTest project templates right now do not have the right method signatures for the initialize and cleanup methods which prevents the tests from running. This PR fixes that!